### PR TITLE
渡邉さんを非表示＆ページネーションを修正

### DIFF
--- a/src/components/company/NewShop.tsx
+++ b/src/components/company/NewShop.tsx
@@ -38,7 +38,7 @@ export default function NewShop() {
                   <div className={styles.nemuVertical}>
                     公式LINEよりご連絡ください。
                   </div>
-                  <Link href={"https://line.me/R/ti/p/%40511gsugf"} passHref>
+                  <Link href={"https://page.line.me/153jsnax?openQrModal=true"} passHref>
                     <p className={styles.line}></p>
                   </Link>
                 </div>

--- a/src/components/company/Noda.tsx
+++ b/src/components/company/Noda.tsx
@@ -38,7 +38,7 @@ export default function Noda() {
                   <div className={styles.nemuVertical}>
                     公式LINEよりご連絡ください。
                   </div>
-                  <Link href={"https://line.me/R/ti/p/%40511gsugf"} passHref>
+                  <Link href={"https://page.line.me/153jsnax?openQrModal=true"} passHref>
                     <p className={styles.line}></p>
                   </Link>
                 </div>

--- a/src/components/company/Shimonakano.tsx
+++ b/src/components/company/Shimonakano.tsx
@@ -38,7 +38,7 @@ export default function Shimonakano() {
                   <div className={styles.nemuVertical}>
                     公式LINEよりご連絡ください。
                   </div>
-                  <Link href={"https://line.me/R/ti/p/%40511gsugf"} passHref>
+                  <Link href={"https://page.line.me/153jsnax?openQrModal=true"} passHref>
                     <p className={styles.line}></p>
                   </Link>
                 </div>

--- a/src/components/pagination/DaiPagination.tsx
+++ b/src/components/pagination/DaiPagination.tsx
@@ -8,14 +8,14 @@ export default function DaiPagination() {
     <>
       <div className={styles.nextFlex}>
         <div className={styles.next}>
-          <Link href={"john"} passHref>
+          <Link href={"natsuki"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Back</span>
             </div>
           </Link>
         </div>
         <div className={styles.next}>
-          <Link href={"natsuki"} passHref>
+          <Link href={"john"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Next</span>
             </div>

--- a/src/components/pagination/FujiiPagination.tsx
+++ b/src/components/pagination/FujiiPagination.tsx
@@ -8,14 +8,14 @@ export default function FujiiPagination() {
     <>
       <div className={styles.nextFlex}>
         <div className={styles.next}>
-          <Link href={"ikemoto"} passHref>
+          <Link href={"john"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Back</span>
             </div>
           </Link>
         </div>
         <div className={styles.next}>
-          <Link href={"john"} passHref>
+          <Link href={"ikemoto"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Next</span>
             </div>

--- a/src/components/pagination/IkemotoPagination.tsx
+++ b/src/components/pagination/IkemotoPagination.tsx
@@ -8,14 +8,14 @@ export default function IkemotoPagination() {
     <>
       <div className={styles.nextFlex}>
         <div className={styles.next}>
-          <Link href={"mai"} passHref>
+          <Link href={"fujii"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Back</span>
             </div>
           </Link>
         </div>
         <div className={styles.next}>
-          <Link href={"fujii"} passHref>
+          <Link href={"mai"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Next</span>
             </div>

--- a/src/components/pagination/JohnPagination.tsx
+++ b/src/components/pagination/JohnPagination.tsx
@@ -8,14 +8,14 @@ export default function JohnPagination() {
     <>
       <div className={styles.nextFlex}>
         <div className={styles.next}>
-          <Link href={"fujii"} passHref>
+          <Link href={"dai"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Back</span>
             </div>
           </Link>
         </div>
         <div className={styles.next}>
-          <Link href={"dai"} passHref>
+          <Link href={"fujii"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Next</span>
             </div>

--- a/src/components/pagination/KatayamaPagination.tsx
+++ b/src/components/pagination/KatayamaPagination.tsx
@@ -8,14 +8,14 @@ export default function KatayamaPagination() {
     <>
       <div className={styles.nextFlex}>
         <div className={styles.next}>
-          <Link href={"mika"} passHref>
+          <Link href={"tomoya"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Back</span>
             </div>
           </Link>
         </div>
         <div className={styles.next}>
-          <Link href={"kaho"} passHref>
+          <Link href={"mika"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Next</span>
             </div>

--- a/src/components/pagination/MahoPagination.tsx
+++ b/src/components/pagination/MahoPagination.tsx
@@ -8,14 +8,14 @@ export default function MahoPagination() {
     <>
       <div className={styles.nextFlex}>
         <div className={styles.next}>
-          <Link href={"nami"} passHref>
+          <Link href={"yuka"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Back</span>
             </div>
           </Link>
         </div>
         <div className={styles.next}>
-          <Link href={"yuka"} passHref>
+          <Link href={"nami"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Next</span>
             </div>

--- a/src/components/pagination/MaiPagination.tsx
+++ b/src/components/pagination/MaiPagination.tsx
@@ -8,14 +8,14 @@ export default function MaiPagination() {
     <>
       <div className={styles.nextFlex}>
         <div className={styles.next}>
-          <Link href={"yuka"} passHref>
+          <Link href={"ikemoto"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Back</span>
             </div>
           </Link>
         </div>
         <div className={styles.next}>
-          <Link href={"ikemoto"} passHref>
+          <Link href={"yuka"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Next</span>
             </div>

--- a/src/components/pagination/MikaPagination.tsx
+++ b/src/components/pagination/MikaPagination.tsx
@@ -8,14 +8,14 @@ export default function MikaPagination() {
     <>
       <div className={styles.nextFlex}>
         <div className={styles.next}>
-          <Link href={"nozomi"} passHref>
+          <Link href={"katayama"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Back</span>
             </div>
           </Link>
         </div>
         <div className={styles.next}>
-          <Link href={"katayama"} passHref>
+          <Link href={"nozomi"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Next</span>
             </div>

--- a/src/components/pagination/NamiPagination.tsx
+++ b/src/components/pagination/NamiPagination.tsx
@@ -8,14 +8,14 @@ export default function NamiPagination() {
     <>
       <div className={styles.nextFlex}>
         <div className={styles.next}>
-          <Link href={"tomoya"} passHref>
+          <Link href={"maho"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Back</span>
             </div>
           </Link>
         </div>
         <div className={styles.next}>
-          <Link href={"maho"} passHref>
+          <Link href={"tomoya"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Next</span>
             </div>

--- a/src/components/pagination/NatsukiPagination.tsx
+++ b/src/components/pagination/NatsukiPagination.tsx
@@ -8,14 +8,14 @@ export default function NatsukiPagination() {
     <>
       <div className={styles.nextFlex}>
         <div className={styles.next}>
-          <Link href={"dai"} passHref>
+          <Link href={"nozomi"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Back</span>
             </div>
           </Link>
         </div>
         <div className={styles.next}>
-          <Link href={"nozomi"} passHref>
+          <Link href={"dai"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Next</span>
             </div>

--- a/src/components/pagination/NozomiPagination.tsx
+++ b/src/components/pagination/NozomiPagination.tsx
@@ -8,14 +8,14 @@ export default function NozomiPagination() {
     <>
       <div className={styles.nextFlex}>
         <div className={styles.next}>
-          <Link href={"natsuki"} passHref>
+          <Link href={"mika"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Back</span>
             </div>
           </Link>
         </div>
         <div className={styles.next}>
-          <Link href={"mika"} passHref>
+          <Link href={"natsuki"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Next</span>
             </div>

--- a/src/components/pagination/TomoyaPagination.tsx
+++ b/src/components/pagination/TomoyaPagination.tsx
@@ -8,14 +8,14 @@ export default function TomoyaPagination() {
     <>
       <div className={styles.nextFlex}>
         <div className={styles.next}>
-          <Link href={"kaho"} passHref>
+          <Link href={"nami"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Back</span>
             </div>
           </Link>
         </div>
         <div className={styles.next}>
-          <Link href={"nami"} passHref>
+          <Link href={"katayama"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Next</span>
             </div>

--- a/src/components/pagination/YukaPagination.tsx
+++ b/src/components/pagination/YukaPagination.tsx
@@ -8,14 +8,14 @@ export default function YukaPagination() {
     <>
       <div className={styles.nextFlex}>
         <div className={styles.next}>
-          <Link href={"maho"} passHref>
+          <Link href={"mai"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Back</span>
             </div>
           </Link>
         </div>
         <div className={styles.next}>
-          <Link href={"mai"} passHref>
+          <Link href={"maho"} passHref>
             <div className={styles.nextInner}>
               <span className={styles.nextInnerIn}>Next</span>
             </div>

--- a/src/pages/stylist/[stylist].tsx
+++ b/src/pages/stylist/[stylist].tsx
@@ -22,7 +22,7 @@ import YukaSNS from "../../components/sns/YukaSNS";
 import MahoSNS from "../../components/sns/MahoSNS";
 import NamiSNS from "../../components/sns/NamiSNS";
 import TomoyaSNS from "../../components/sns/TomoyaSNS";
-import KahoSNS from "../../components/sns/KahoSNS";
+// import KahoSNS from "../../components/sns/KahoSNS";
 // 各スタイリストのMenuを読み込む(暫定適用)
 import Katayama from "../../components/menu/Katayama";
 import Mika from "../../components/menu/Mika";
@@ -37,7 +37,7 @@ import Yuka from "../../components/menu/Yuka";
 import Maho from "../../components/menu/Maho";
 import Nami from "../../components/menu/Nami";
 import Tomoya from "../../components/menu/Tomoya";
-import Kaho from "../../components/menu/Kaho";
+// import Kaho from "../../components/menu/Kaho";
 // 各スタイリストのPaginationを読み込む(暫定適用)
 import KatayamaPagination from "../../components/pagination/KatayamaPagination";
 import MikaPagination from "../../components/pagination/MikaPagination";
@@ -52,7 +52,7 @@ import YukaPagination from "../../components/pagination/YukaPagination";
 import MahoPagination from "../../components/pagination/MahoPagination";
 import NamiPagination from "../../components/pagination/NamiPagination";
 import TomoyaPagination from "../../components/pagination/TomoyaPagination";
-import KahoPagination from "../../components/pagination/KahoPagination";
+// import KahoPagination from "../../components/pagination/KahoPagination";
 
 type Props = {
   stylist: Stylist;
@@ -108,7 +108,7 @@ export default function Stylist({ stylist }: Props) {
                       {id == 11 && <MahoSNS />}
                       {id == 12 && <NamiSNS />}
                       {id == 13 && <TomoyaSNS />}
-                      {id == 14 && <KahoSNS />}
+                      {/* {id == 14 && <KahoSNS />} */}
                     </div>
                   );
                 })}
@@ -202,7 +202,7 @@ export default function Stylist({ stylist }: Props) {
                 {id == 11 && <Maho />}
                 {id == 12 && <Nami />}
                 {id == 13 && <Tomoya />}
-                {id == 14 && <Kaho />}
+                {/* {id == 14 && <Kaho />} */}
               </div>
             );
           })}
@@ -238,7 +238,7 @@ export default function Stylist({ stylist }: Props) {
                 {id == 11 && <MahoPagination />}
                 {id == 12 && <NamiPagination />}
                 {id == 13 && <TomoyaPagination />}
-                {id == 14 && <KahoPagination />}
+                {/* {id == 14 && <KahoPagination />} */}
               </div>
             );
           })}


### PR DESCRIPTION
【変更ファイル】
・ src/pages/stylist/[stylist].tsx
・src/components/pagination/DaiPagination.tsx
・src/components/pagination/FujiiPagination.tsx
・src/components/pagination/IkemotoPagination.tsx
・src/components/pagination/JohnPagination.tsx
・src/components/pagination/KatayamaPagination.tsx
・src/components/pagination/MahoPagination.tsx
・src/components/pagination/MaiPagination.tsx
・src/components/pagination/MikaPagination.tsx
・src/components/pagination/NamiPagination.tsx
・src/components/pagination/NatsukiPagination.tsx
・src/components/pagination/NozomiPagination.tsx
・src/components/pagination/TomoyaPagination.tsx
・src/components/pagination/YukaPagination.tsx

【変更内容】
・渡邉さんのページを非表示にしました
・各スタイリストのページネーションがNextの値とBackの値が逆になっていたので修正しました。

【課題】
・渡邉さんのページの公開を3/1に予定
・ローカル開発環境で完成形を確認し、渡邉さんからOKをもらえたら公開可能